### PR TITLE
Updated alt text for 06_first_plot.png

### DIFF
--- a/_episodes/07-visualization-ggplot-python.md
+++ b/_episodes/07-visualization-ggplot-python.md
@@ -223,7 +223,7 @@ operator:
 ~~~
 {: .language-python}
 
-![png](../fig/06_color_label_plot.png)
+![scatter plot of Hindfoot length vs weight (g) with colors coordinating to specfic species, showing abundance in the mid to lower left side of the plot](../fig/06_color_label_plot.png)
 
 - Defining scale for colors, axes,... For example, a log-version of the x-axis
 could support the interpretation of the lower numbers:
@@ -447,7 +447,7 @@ We can apply the same concept on any of the available categorical variables:
 ~~~
 {: .language-python}
 
-![png](../fig/06_facet_all_plot.png)
+![24 individual scatter plots of Hindfoot length vs weight of species with colors denoting species and numbers above plot representing 1 of the 24 plots, showing trends for each unique plot id studied](../fig/06_facet_all_plot.png)
 
 The `facet_wrap` geometry extracts plots into an arbitrary number of dimensions
 to allow them to cleanly fit on one page. On the other hand, the `facet_grid`


### PR DESCRIPTION
The original commit accidentally removed previous alt text addition, so this is to mend those and make sure 06_first_plot.png[line:126], 06_color_label_plot.png[line:226], and 06_facet_all_plot.png[line:450] all match approved alt text from spreadsheet.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
